### PR TITLE
fix nil ptr error on apple m1 chip

### DIFF
--- a/mdbx/val.go
+++ b/mdbx/val.go
@@ -112,5 +112,8 @@ func wrapVal(b []byte) *C.MDBX_val {
 }
 
 func castToBytes(val *C.MDBX_val) []byte {
+	if val.iov_len == 0 {
+		return nil
+	}
 	return (*[valMaxSize]byte)(val.iov_base)[:val.iov_len:val.iov_len]
 }

--- a/mdbx/val.go
+++ b/mdbx/val.go
@@ -113,7 +113,7 @@ func wrapVal(b []byte) *C.MDBX_val {
 
 func castToBytes(val *C.MDBX_val) []byte {
 	if val.iov_len == 0 {
-		return nil
+		return []byte{}
 	}
 	return (*[valMaxSize]byte)(val.iov_base)[:val.iov_len:val.iov_len]
 }


### PR DESCRIPTION
When running TestEmptyValue on my m1 mac, it panics during the cast of val.iov_base -> *[valMaxSize]byte

i dont know exactly why - maybe mdbx on arm returns an invalid pointer to data when there is 0 length data?

to fix, i add this fast path simply returns []byte{} when the length is 0, a non nil value that should not break any existing code. from what i see, this slice should be read only, and so if there was behavior that relied on modifying this, it is not intended use.

