### PR TITLE
Expose C handle for MDBX environment

### DIFF
--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -618,3 +618,7 @@ func (env *Env) run(lock bool, flags uint, fn TxnOp) error {
 func (env *Env) CloseDBI(db DBI) {
 	C.mdbx_dbi_close(env._env, C.MDBX_dbi(db))
 }
+
+func (env *Env) CHandle() unsafe.Pointer {
+	return unsafe.Pointer(env._env)
+}


### PR DESCRIPTION
This is necessary for Silkworm RPC daemon embedded in Erigon