### PR TITLE
No pointer optimisation txn

### DIFF
--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -159,7 +159,7 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 	}
 	if err != nil {
 		*c.txn.key = C.MDBX_val{}
-		*c.txn.val = C.MDBX_val{}
+		c.txn.val = C.MDBX_val{}
 		return nil, nil, err
 	}
 
@@ -174,12 +174,12 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 			key = castToBytes(c.txn.key)
 		}
 	}
-	val = castToBytes(c.txn.val)
+	val = castToBytes(&c.txn.val)
 
 	// Clear transaction storage record storage area for future use and to
 	// prevent dangling references.
 	*c.txn.key = C.MDBX_val{}
-	*c.txn.val = C.MDBX_val{}
+	c.txn.val = C.MDBX_val{}
 
 	return key, val, nil
 }
@@ -189,7 +189,7 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 //
 // See mdb_cursor_get.
 func (c *Cursor) getVal0(op uint) error {
-	ret := C.mdbx_cursor_get(c._c, c.txn.key, c.txn.val, C.MDBX_cursor_op(op))
+	ret := C.mdbx_cursor_get(c._c, c.txn.key, &c.txn.val, C.MDBX_cursor_op(op))
 	return operrno("mdbx_cursor_get", ret)
 }
 
@@ -206,7 +206,7 @@ func (c *Cursor) getVal1(setkey []byte, op uint) error {
 		c._c,
 		k, C.size_t(len(setkey)),
 		c.txn.key,
-		c.txn.val,
+		&c.txn.val,
 		C.MDBX_cursor_op(op),
 	)
 	return operrno("mdbx_cursor_get", ret)
@@ -220,7 +220,7 @@ func (c *Cursor) getVal01(setval []byte, op uint) error {
 		c._c,
 		v, C.size_t(len(setval)),
 		c.txn.key,
-		c.txn.val,
+		&c.txn.val,
 		C.MDBX_cursor_op(op),
 	)
 	return operrno("mdbx_cursor_get", ret)
@@ -242,7 +242,7 @@ func (c *Cursor) getVal2(setkey, setval []byte, op uint) error {
 		c._c,
 		k, C.size_t(len(setkey)),
 		v, C.size_t(len(setval)),
-		c.txn.key, c.txn.val,
+		c.txn.key, &c.txn.val,
 		C.MDBX_cursor_op(op),
 	)
 	return operrno("mdbx_cursor_get", ret)
@@ -280,16 +280,16 @@ func (c *Cursor) PutReserve(key []byte, n int, flags uint) ([]byte, error) {
 	ret := C.mdbxgo_cursor_put1(
 		c._c,
 		k, C.size_t(len(key)),
-		c.txn.val,
+		&c.txn.val,
 		C.MDBX_put_flags_t(flags|C.MDBX_RESERVE),
 	)
 	err := operrno("mdbx_cursor_put", ret)
 	if err != nil {
-		*c.txn.val = C.MDBX_val{}
+		c.txn.val = C.MDBX_val{}
 		return nil, err
 	}
-	b := castToBytes(c.txn.val)
-	*c.txn.val = C.MDBX_val{}
+	b := castToBytes(&c.txn.val)
+	c.txn.val = C.MDBX_val{}
 	return b, nil
 }
 

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -93,14 +93,12 @@ func beginTxn(env *Env, parent *Txn, flags uint) (*Txn, error) {
 			// In a write Txn we can use the shared, C-allocated key and value
 			// allocated by env, and freed when it is closed.
 			txn.key = env.ckey
-			txn.val = *env.cval
 		} else {
 			// It is not easy to share C.MDBX_val values in this scenario unless
 			// there is a synchronized pool involved, which will increase
 			// overhead.  Further, allocating these values with C will add
 			// overhead both here and when the values are freed.
 			txn.key = new(C.MDBX_val)
-			txn.val = C.MDBX_val{}
 		}
 	} else {
 		// Because parent Txn objects cannot be used while a sub-Txn is active

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -594,35 +594,15 @@ func (txn *Txn) Get(dbi DBI, key []byte) ([]byte, error) {
 	ret := C.mdbxgo_get(
 		txn._txn, C.MDBX_dbi(dbi),
 		k, C.size_t(len(key)),
-		txn.val,
-	)
-	err := operrno("mdbx_get", ret)
-	if err != nil {
-		*txn.val = C.MDBX_val{}
-		return nil, err
-	}
-	b := castToBytes(txn.val)
-	*txn.val = C.MDBX_val{}
-	return b, nil
-}
-
-func (txn *Txn) GetFast(dbi DBI, key []byte) ([]byte, error) {
-	var k *C.char
-	if len(key) > 0 {
-		k = (*C.char)(unsafe.Pointer(&key[0]))
-	}
-	ret := C.mdbxgo_get(
-		txn._txn, C.MDBX_dbi(dbi),
-		k, C.size_t(len(key)),
 		&txn.valNP,
 	)
 	err := operrno("mdbx_get", ret)
 	if err != nil {
-		txn.valNP = C.MDBX_val{}
+		txn.valNP.iov_base, txn.valNP.iov_len = nil, 0
 		return nil, err
 	}
 	b := castToBytes(&txn.valNP)
-	txn.valNP = C.MDBX_val{}
+	txn.valNP.iov_base, txn.valNP.iov_len = nil, 0
 	return b, nil
 }
 

--- a/mdbx/txn_test.go
+++ b/mdbx/txn_test.go
@@ -1299,42 +1299,6 @@ func BenchmarkTxn_Get(b *testing.B) {
 	}
 }
 
-func BenchmarkTxn_GetFast(b *testing.B) {
-	env, _ := setup(b)
-
-	var db DBI
-	k := make([]byte, 8)
-	binary.BigEndian.PutUint64(k, uint64(1))
-
-	if err := env.Update(func(txn *Txn) (err error) {
-		db, err = txn.OpenRoot(0)
-		if err != nil {
-			return err
-		}
-		err = txn.Put(db, k, k, 0)
-		if err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		b.Errorf("dbi: %v", err)
-		return
-	}
-
-	if err := env.View(func(txn *Txn) (err error) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, err := txn.GetFast(db, k)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		b.Errorf("put: %v", err)
-	}
-}
-
 func TestTxnEnvWarmup(t *testing.T) {
 	env, _ := setup(t)
 


### PR DESCRIPTION
Added optimization that changed txn.val to non-pointer that allows us to avoid cgoCheckUnknownPointer false-positive cgo behavior. 
CI Check in Erigon: https://github.com/ledgerwatch/erigon/pull/10708