### PR TITLE
Key non pointer opt

### DIFF
--- a/dbg/pprof_cgo.go
+++ b/dbg/pprof_cgo.go
@@ -4,5 +4,5 @@
 package dbg
 
 import (
-	_ "github.com/benesch/cgosymbolizer"
+	_ "github.com/ianlancetaylor/cgosymbolizer"
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/erigontech/mdbx-go
 
 go 1.15
 
-require (
-	github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b
-	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20240503222823-736c933a666d // indirect
-)
+require github.com/ianlancetaylor/cgosymbolizer v0.0.0-20240503222823-736c933a666d

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b h1:5JgaFtHFRnOPReItxvhMDXbvuBkjSWE+9glJyF466yw=
-github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b/go.mod h1:eMD2XUcPsHYbakFEocKrWZp47G0MRJYoC60qFblGjpA=
 github.com/ianlancetaylor/cgosymbolizer v0.0.0-20240503222823-736c933a666d h1:Azx2B59D4+zpVVtuYb8Oe3uOLi/ift4xfwKdhBX0Cy0=
 github.com/ianlancetaylor/cgosymbolizer v0.0.0-20240503222823-736c933a666d/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -158,7 +158,7 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 		err = c.getVal2(setkey, setval, op)
 	}
 	if err != nil {
-		*c.txn.key = C.MDBX_val{}
+		c.txn.key = C.MDBX_val{}
 		c.txn.val = C.MDBX_val{}
 		return nil, nil, err
 	}
@@ -171,14 +171,14 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 		key = setkey
 	} else {
 		if op != LastDup && op != FirstDup {
-			key = castToBytes(c.txn.key)
+			key = castToBytes(&c.txn.key)
 		}
 	}
 	val = castToBytes(&c.txn.val)
 
 	// Clear transaction storage record storage area for future use and to
 	// prevent dangling references.
-	*c.txn.key = C.MDBX_val{}
+	c.txn.key = C.MDBX_val{}
 	c.txn.val = C.MDBX_val{}
 
 	return key, val, nil
@@ -189,7 +189,7 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 //
 // See mdb_cursor_get.
 func (c *Cursor) getVal0(op uint) error {
-	ret := C.mdbx_cursor_get(c._c, c.txn.key, &c.txn.val, C.MDBX_cursor_op(op))
+	ret := C.mdbx_cursor_get(c._c, &c.txn.key, &c.txn.val, C.MDBX_cursor_op(op))
 	return operrno("mdbx_cursor_get", ret)
 }
 
@@ -205,7 +205,7 @@ func (c *Cursor) getVal1(setkey []byte, op uint) error {
 	ret := C.mdbxgo_cursor_get1(
 		c._c,
 		k, C.size_t(len(setkey)),
-		c.txn.key,
+		&c.txn.key,
 		&c.txn.val,
 		C.MDBX_cursor_op(op),
 	)
@@ -219,7 +219,7 @@ func (c *Cursor) getVal01(setval []byte, op uint) error {
 	ret := C.mdbxgo_cursor_get01(
 		c._c,
 		v, C.size_t(len(setval)),
-		c.txn.key,
+		&c.txn.key,
 		&c.txn.val,
 		C.MDBX_cursor_op(op),
 	)
@@ -242,7 +242,7 @@ func (c *Cursor) getVal2(setkey, setval []byte, op uint) error {
 		c._c,
 		k, C.size_t(len(setkey)),
 		v, C.size_t(len(setval)),
-		c.txn.key, &c.txn.val,
+		&c.txn.key, &c.txn.val,
 		C.MDBX_cursor_op(op),
 	)
 	return operrno("mdbx_cursor_get", ret)

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -59,7 +59,7 @@ const (
 type Txn struct {
 	env  *Env
 	_txn *C.MDBX_txn
-	key  *C.MDBX_val
+	key  C.MDBX_val
 	val  C.MDBX_val
 
 	errLogf func(format string, v ...interface{})
@@ -92,13 +92,13 @@ func beginTxn(env *Env, parent *Txn, flags uint) (*Txn, error) {
 		if flags&Readonly == 0 {
 			// In a write Txn we can use the shared, C-allocated key and value
 			// allocated by env, and freed when it is closed.
-			txn.key = env.ckey
+			txn.key = *env.ckey
 		} else {
 			// It is not easy to share C.MDBX_val values in this scenario unless
 			// there is a synchronized pool involved, which will increase
 			// overhead.  Further, allocating these values with C will add
 			// overhead both here and when the values are freed.
-			txn.key = new(C.MDBX_val)
+			txn.key = C.MDBX_val{}
 		}
 	} else {
 		// Because parent Txn objects cannot be used while a sub-Txn is active


### PR DESCRIPTION
```
goarch: amd64
pkg: github.com/erigontech/mdbx-go/mdbx
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
                        │ txn_key_pointer.txt │       txn_key_non_pointer.txt        │
                        │       sec/op        │    sec/op     vs base                │
Cursor-20                         169.8n ± 2%   168.2n ±  1%        ~ (p=0.092 n=10)
Cursor_Renew/1-20                 57.66n ± 3%   57.40n ±  5%        ~ (p=0.895 n=10)
Cursor_Renew/2-20                 55.76n ± 2%   55.95n ±  3%        ~ (p=0.225 n=10)
Cursor_Renew/3-20                 167.4n ± 4%   167.5n ±  1%        ~ (p=0.927 n=10)
Cursor_Renew/4-20                 61.62n ± 5%   61.87n ±  4%        ~ (p=0.481 n=10)
Cursor_SetRange-20                89.00n ± 3%   76.91n ±  2%  -13.59% (p=0.000 n=10)
Errno_Error-20                    364.7n ± 7%   348.7n ± 10%        ~ (p=0.165 n=10)
Txn_abort-20                      217.7n ± 2%   220.7n ±  5%        ~ (p=0.066 n=10)
Txn_ro-20                         433.4n ± 6%   428.3n ±  6%        ~ (p=0.579 n=10)
Txn_unmanaged_abort-20            191.6n ± 4%   201.3n ±  3%   +5.09% (p=0.001 n=10)
Txn_unmanaged_commit-20           197.4n ± 3%   203.3n ±  3%   +2.99% (p=0.001 n=10)
Txn_unmanaged_ro-20               281.8n ± 2%   261.6n ±  3%   -7.19% (p=0.000 n=10)
Txn_renew-20                      118.9n ± 4%   114.4n ±  3%   -3.78% (p=0.037 n=10)
Txn_Get-20                        72.98n ± 4%   72.21n ±  1%   -1.06% (p=0.015 n=10)
geomean                           143.7n        141.2n         -1.70%
```
