### PR TITLE
Fix typo Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ contributors to follow.
     See previous sections for information about opening new issues.
 
 2.  Pull requests must mention the corresponding issue number in their
-    description using the github convention format #XXX.  If the pull requset
+    description using the github convention format #XXX.  If the pull request
     resolves an issue then the description should contain the line "Fixes #XXX",
     so the issue will be closed automatically after merging the pull request.
 


### PR DESCRIPTION
I fixed a typo in the CONTRIBUTING.md file, correcting the word "requset" to "request".

Specific Change:
Before:
If the pull requset
After:
If the pull request
This correction ensures proper spelling and improves the clarity and professionalism of the contributing guidelines.