### PR TITLE
Add unsynced bytes to EnvInfo

### DIFF
--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -350,6 +350,7 @@ type EnvInfo struct {
 	SystemPageSize    uint          //
 	MiLastPgNo        uint64        //
 	AutoSyncThreshold uint          //
+	UnsyncedBytes     uint          // how many bytes have been committed but not flushed yet to disk
 	SinceSync         time.Duration //
 	AutosyncPeriod    time.Duration //
 	SinceReaderCheck  time.Duration //
@@ -423,6 +424,7 @@ func castEnvInfo(_info C.MDBX_envinfo) *EnvInfo {
 		MiLastPgNo:     uint64(_info.mi_last_pgno),
 
 		AutoSyncThreshold: uint(_info.mi_autosync_threshold),
+		UnsyncedBytes:     uint(_info.mi_unsync_volume),
 		SinceSync:         toDuration(_info.mi_since_sync_seconds16dot16),
 		AutosyncPeriod:    toDuration(_info.mi_autosync_period_seconds16dot16),
 		SinceReaderCheck:  toDuration(_info.mi_since_reader_check_seconds16dot16),


### PR DESCRIPTION
This counts the number of bytes committed in the DB (in the memory map), but not yet flushed to disk.