### PR TITLE
backport(v0.41.1): mdbx: Cursor.Open initializes in place so callers can embed Cursor by value

### DIFF
--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -103,12 +103,31 @@ type Cursor struct {
 	_c  *C.MDBX_cursor
 }
 
+// Open binds an unopened Cursor to the table in place. Unlike Txn.OpenCursor it
+// does not allocate the Cursor, so callers may embed Cursor by value. Close is
+// still required.
+//
 //nolint:gocritic // reason: false positive on dupSubExpr
-func openCursor(txn *Txn, db DBI) (*Cursor, error) {
-	c := &Cursor{txn: txn}
+func (c *Cursor) Open(txn *Txn, db DBI) error {
+	if c._c != nil {
+		return errors.New("mdbx.Cursor.Open: cursor is already open")
+	}
 	ret := C.mdbx_cursor_open(txn._txn, C.MDBX_dbi(db), &c._c)
 	if ret != success {
-		return nil, operrno("mdbx_cursor_open", ret)
+		return operrno("mdbx_cursor_open", ret)
+	}
+	c.txn = txn
+	return nil
+}
+
+// IsClosed reports whether the cursor holds no libmdbx cursor, i.e. it was
+// never opened or has already been closed.
+func (c *Cursor) IsClosed() bool { return c._c == nil }
+
+func openCursor(txn *Txn, db DBI) (*Cursor, error) {
+	c := &Cursor{}
+	if err := c.Open(txn, db); err != nil {
+		return nil, err
 	}
 	return c, nil
 }

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -120,9 +120,10 @@ func (c *Cursor) Open(txn *Txn, db DBI) error {
 	return nil
 }
 
-// IsClosed reports whether the cursor holds no libmdbx cursor, i.e. it was
-// never opened or has already been closed.
-func (c *Cursor) IsClosed() bool { return c._c == nil }
+// IsClosed reports whether the cursor holds no libmdbx cursor, i.e. it is nil,
+// was never opened, or has already been closed. Nil-safe so it fully replaces
+// the nil-*Cursor checks callers used before Open existed.
+func (c *Cursor) IsClosed() bool { return c == nil || c._c == nil }
 
 func openCursor(txn *Txn, db DBI) (*Cursor, error) {
 	c := &Cursor{}
@@ -176,6 +177,9 @@ func (c *Cursor) Unbind() error {
 //
 // See mdbx_cursor_close.
 func (c *Cursor) Close() {
+	if c == nil {
+		return
+	}
 	if c._c != nil {
 		C.mdbx_cursor_close(c._c)
 		c.txn = nil

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -109,6 +109,12 @@ type Cursor struct {
 //
 //nolint:gocritic // reason: false positive on dupSubExpr
 func (c *Cursor) Open(txn *Txn, db DBI) error {
+	if c == nil {
+		return errors.New("mdbx.Cursor.Open: nil cursor: Open initializes in place, so it needs an addressable Cursor")
+	}
+	if txn == nil || txn._txn == nil {
+		return errors.New("mdbx.Cursor.Open: nil transaction")
+	}
 	if c._c != nil {
 		return errors.New("mdbx.Cursor.Open: cursor is already open")
 	}

--- a/mdbx/cursor_lifecycle_test.go
+++ b/mdbx/cursor_lifecycle_test.go
@@ -260,3 +260,13 @@ func TestCursor_OpenInPlace_RejectsReopen(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// A nil *Cursor is the state callers used to represent "closed" before Open
+// existed, so the lifecycle predicates must tolerate it.
+func TestCursorNilReceiver(t *testing.T) {
+	var c *Cursor
+	if !c.IsClosed() {
+		t.Fatal("a nil *Cursor must report closed")
+	}
+	c.Close() // must not panic
+}

--- a/mdbx/cursor_lifecycle_test.go
+++ b/mdbx/cursor_lifecycle_test.go
@@ -177,3 +177,86 @@ func TestCursorPool_UnboundOnReturn(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// A zero-value Cursor can be initialized in place, so callers may embed Cursor
+// by value instead of holding a *Cursor from Txn.OpenCursor.
+func TestCursor_OpenInPlace(t *testing.T) {
+	env, _ := setup(t)
+
+	var db DBI
+	err := env.Update(func(txn *Txn) (err error) {
+		db, err = txn.OpenDBISimple("testing_openinplace", Create)
+		if err != nil {
+			return err
+		}
+		return txn.Put(db, []byte("k"), []byte("v"), 0)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = env.View(func(txn *Txn) error {
+		var holder struct{ cur Cursor }
+		if !holder.cur.IsClosed() {
+			t.Error("zero-value Cursor reports open")
+		}
+		if err := holder.cur.Open(txn, db); err != nil {
+			return err
+		}
+		if holder.cur.IsClosed() {
+			t.Error("Cursor reports closed after Open")
+		}
+		if holder.cur.Txn() != txn {
+			t.Error("Cursor.Txn() does not report the opening txn")
+		}
+		if holder.cur.DBI() != db {
+			t.Error("Cursor.DBI() does not report the opened table")
+		}
+		k, v, err := holder.cur.Get(nil, nil, First)
+		if err != nil {
+			return err
+		}
+		if string(k) != "k" || string(v) != "v" {
+			t.Errorf(`got %q=%q, want "k"="v"`, k, v)
+		}
+		holder.cur.Close()
+		if !holder.cur.IsClosed() {
+			t.Error("Cursor reports open after Close")
+		}
+		holder.cur.Close()
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// Reopening in place would drop the first libmdbx cursor without closing it, so
+// Open refuses rather than leaking it.
+func TestCursor_OpenInPlace_RejectsReopen(t *testing.T) {
+	env, _ := setup(t)
+
+	var db DBI
+	err := env.Update(func(txn *Txn) (err error) {
+		db, err = txn.OpenDBISimple("testing_openinplace_reopen", Create)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = env.View(func(txn *Txn) error {
+		var cur Cursor
+		if err := cur.Open(txn, db); err != nil {
+			return err
+		}
+		defer cur.Close()
+		if err := cur.Open(txn, db); err == nil {
+			t.Error("second Open on an open cursor returned nil error")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/mdbx/cursor_lifecycle_test.go
+++ b/mdbx/cursor_lifecycle_test.go
@@ -270,3 +270,20 @@ func TestCursorNilReceiver(t *testing.T) {
 	}
 	c.Close() // must not panic
 }
+
+// Open initializes in place, so the degenerate receivers it can be handed must
+// come back as errors rather than a cgo-level nil dereference.
+func TestCursorOpenNilArgs(t *testing.T) {
+	var nilCursor *Cursor
+	if err := nilCursor.Open(nil, 0); err == nil {
+		t.Fatal("Open on a nil *Cursor must return an error")
+	}
+
+	var c Cursor
+	if err := c.Open(nil, 0); err == nil {
+		t.Fatal("Open with a nil *Txn must return an error")
+	}
+	if !c.IsClosed() {
+		t.Fatal("a failed Open must leave the cursor closed")
+	}
+}


### PR DESCRIPTION
Cherry-pick of #248 to `release/v0.41.0`.

`v0.41.0` vendors the same libmdbx tree as `v0.40.3` (`ba27cbcd…`, libmdbx v0.14.2) — the tree hashes are identical, the v0.40.3→v0.41.0 delta is Go-side only. So this line gives Erigon `Cursor.Open` on exactly the libmdbx it already runs, without waiting on the libmdbx bump in #245.

`release/v0.41.0` was branched at the `v0.41.0` tag, following the `release/v0.40.3` precedent.

## Intended tag: `v0.41.1`, not `v0.41.0.1`

The existing patch tags `v0.40.3.1` and `v0.39.19.1` have four numeric components, which is not valid semver, so the Go module system ignores them — they never appear in `go list -m -versions`, and `go get …@v0.40.3.1` silently resolves to the pseudo-version `v0.40.4-0.20260723081653-014127a19c7b`. A `v0.41.0.1` tag would be unusable as a clean pin.

`v0.41.1` is valid semver and correct here: `Cursor.Open` and `IsClosed` are additive, `Txn.OpenCursor` keeps its signature.

## Validation

Tree is byte-identical to #248's head. `go build ./...` and `go test ./mdbx ./exp/mdbxpool` pass on this base.
