### PR TITLE
mdbx: bar copying Cursor and Txn with noCopy

### DIFF
--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -98,16 +98,6 @@ const (
 // database.
 //
 // See MDB_cursor.
-// noCopy makes `go vet -copylocks` reject copies of a Cursor. A Cursor owns a
-// raw libmdbx cursor, so a copy would give two values one underlying cursor:
-// Close on either frees it while the other still points at it. Zero-sized and
-// first in the struct, so it costs no space. Not embedded — that would export
-// Lock/Unlock on Cursor.
-type noCopy struct{}
-
-func (*noCopy) Lock()   {}
-func (*noCopy) Unlock() {}
-
 type Cursor struct {
 	noCopy noCopy
 	txn    *Txn

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -98,9 +98,20 @@ const (
 // database.
 //
 // See MDB_cursor.
+// noCopy makes `go vet -copylocks` reject copies of a Cursor. A Cursor owns a
+// raw libmdbx cursor, so a copy would give two values one underlying cursor:
+// Close on either frees it while the other still points at it. Zero-sized and
+// first in the struct, so it costs no space. Not embedded — that would export
+// Lock/Unlock on Cursor.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
+
 type Cursor struct {
-	txn *Txn
-	_c  *C.MDBX_cursor
+	noCopy noCopy
+	txn    *Txn
+	_c     *C.MDBX_cursor
 }
 
 // Open binds an unopened Cursor to the table in place. Unlike Txn.OpenCursor it

--- a/mdbx/cursor_lifecycle_test.go
+++ b/mdbx/cursor_lifecycle_test.go
@@ -287,3 +287,15 @@ func TestCursorOpenNilArgs(t *testing.T) {
 		t.Fatal("a failed Open must leave the cursor closed")
 	}
 }
+
+// Embedding a Cursor by value is the pattern Open exists for, so noCopy must
+// not stand in its way — it bars copying the Cursor, not holding one.
+func TestCursorEmbedByValue(t *testing.T) {
+	type holder struct{ c Cursor }
+
+	h := &holder{}
+	if !h.c.IsClosed() {
+		t.Fatal("a zero embedded Cursor must report closed")
+	}
+	h.c.Close() // no-op on a never-opened cursor
+}

--- a/mdbx/nocopy.go
+++ b/mdbx/nocopy.go
@@ -1,0 +1,14 @@
+package mdbx
+
+// noCopy makes `go vet -copylocks` reject copies of the type embedding it.
+// The C-handle types here own a raw libmdbx object, so a copy would give two
+// values one underlying handle: closing either frees it while the other still
+// points at it.
+//
+// Zero-sized, so it costs no space when placed first in a struct. Held as a
+// named field rather than embedded, which would promote Lock/Unlock onto the
+// enclosing type's method set.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -60,6 +60,11 @@ const (
 //
 // See MDBX_txn.
 type Txn struct {
+	// noCopy: a Txn owns a raw libmdbx transaction, so a copy would give two
+	// values one underlying txn — Abort or Commit on either leaves the other
+	// pointing at freed memory. Env is already covered by its closeLock.
+	noCopy noCopy
+
 	env  *Env
 	_txn *C.MDBX_txn
 	// val is scratch space for Txn.Get and the PutReserve paths: passing the


### PR DESCRIPTION
Follow-up to #248. Now that a `Cursor` can be embedded by value, copying one is easy to do by accident and nothing rejects it.

The C-handle types own a raw libmdbx object, so a copy hands two Go values one underlying handle: closing either frees it while the other still points at it, and the second close is a double free into cgo.

## Which types actually needed it

| type | holds | before | now |
|---|---|---|---|
| `Env` | `*C.MDBX_env` | already rejected — `closeLock sync.RWMutex` | unchanged |
| `Txn` | `*C.MDBX_txn` | **unguarded** | `noCopy` |
| `Cursor` | `*C.MDBX_cursor` | **unguarded** | `noCopy` |

`Env` needed nothing; I checked rather than assumed. `go vet -copylocks` had nothing to key on for the other two, since neither holds a `sync` type.

```
assignment copies lock value to b: mdbx.Cursor contains mdbx.noCopy
assignment copies lock value to y: mdbx.Txn contains mdbx.noCopy
```

## Not affected

Embedding by value — the reason `Open` exists — still works. noCopy bars *copying* a value, not holding one:

```go
type holder struct{ c mdbx.Cursor }   // fine
h.c.Open(txn, dbi)                    // fine
```

`TestCursorEmbedByValue` pins that, so nobody later "fixes" it back to a pointer.

## Cost

None. `noCopy` is zero-sized and placed first in each struct, so `sizeof(Cursor)` stays 16 bytes. It lives in its own `mdbx/nocopy.go` and is a named field rather than embedded, so `Lock`/`Unlock` are not promoted onto the public method sets.

## Verified

- `go vet ./mdbx/` and `go test ./mdbx/` clean
- deliberate copies of both types rejected by copylocks
- `go doc` still documents `Cursor` and `Txn` correctly
- `go vet ./...` over the whole erigon tree, against a local `replace` — nothing downstream copies either type today, so this breaks no existing caller