### PR TITLE
backport(v0.41.2): mdbx: bar copying Cursor and Txn with noCopy

### DIFF
--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -98,16 +98,6 @@ const (
 // database.
 //
 // See MDB_cursor.
-// noCopy makes `go vet -copylocks` reject copies of a Cursor. A Cursor owns a
-// raw libmdbx cursor, so a copy would give two values one underlying cursor:
-// Close on either frees it while the other still points at it. Zero-sized and
-// first in the struct, so it costs no space. Not embedded — that would export
-// Lock/Unlock on Cursor.
-type noCopy struct{}
-
-func (*noCopy) Lock()   {}
-func (*noCopy) Unlock() {}
-
 type Cursor struct {
 	noCopy noCopy
 	txn    *Txn

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -98,9 +98,20 @@ const (
 // database.
 //
 // See MDB_cursor.
+// noCopy makes `go vet -copylocks` reject copies of a Cursor. A Cursor owns a
+// raw libmdbx cursor, so a copy would give two values one underlying cursor:
+// Close on either frees it while the other still points at it. Zero-sized and
+// first in the struct, so it costs no space. Not embedded — that would export
+// Lock/Unlock on Cursor.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
+
 type Cursor struct {
-	txn *Txn
-	_c  *C.MDBX_cursor
+	noCopy noCopy
+	txn    *Txn
+	_c     *C.MDBX_cursor
 }
 
 // Open binds an unopened Cursor to the table in place. Unlike Txn.OpenCursor it

--- a/mdbx/cursor_lifecycle_test.go
+++ b/mdbx/cursor_lifecycle_test.go
@@ -287,3 +287,15 @@ func TestCursorOpenNilArgs(t *testing.T) {
 		t.Fatal("a failed Open must leave the cursor closed")
 	}
 }
+
+// Embedding a Cursor by value is the pattern Open exists for, so noCopy must
+// not stand in its way — it bars copying the Cursor, not holding one.
+func TestCursorEmbedByValue(t *testing.T) {
+	type holder struct{ c Cursor }
+
+	h := &holder{}
+	if !h.c.IsClosed() {
+		t.Fatal("a zero embedded Cursor must report closed")
+	}
+	h.c.Close() // no-op on a never-opened cursor
+}

--- a/mdbx/nocopy.go
+++ b/mdbx/nocopy.go
@@ -1,0 +1,14 @@
+package mdbx
+
+// noCopy makes `go vet -copylocks` reject copies of the type embedding it.
+// The C-handle types here own a raw libmdbx object, so a copy would give two
+// values one underlying handle: closing either frees it while the other still
+// points at it.
+//
+// Zero-sized, so it costs no space when placed first in a struct. Held as a
+// named field rather than embedded, which would promote Lock/Unlock onto the
+// enclosing type's method set.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -60,6 +60,11 @@ const (
 //
 // See MDBX_txn.
 type Txn struct {
+	// noCopy: a Txn owns a raw libmdbx transaction, so a copy would give two
+	// values one underlying txn — Abort or Commit on either leaves the other
+	// pointing at freed memory. Env is already covered by its closeLock.
+	noCopy noCopy
+
 	env  *Env
 	_txn *C.MDBX_txn
 	// val is scratch space for Txn.Get and the PutReserve paths: passing the


### PR DESCRIPTION
Cherry-pick of #250 to release/v0.41.0.

v0.41.1 shipped `Cursor.Open` (embed by value), which is what makes an accidental copy easy — so the guard belongs on the same line as the hazard.

`Env` needed nothing (its `closeLock sync.RWMutex` already trips copylocks); `Txn` and `Cursor` did.

copylocks is a vet check, not a compile error, so this cannot break a downstream build. Verified: `go vet`/`go test ./mdbx/` clean here, both types reject copies, docs intact, and `go vet ./...` over the whole erigon tree is clean against a local replace.