### PR TITLE
mdbx: expose OptPresyncThreshold

### DIFF
--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -120,6 +120,13 @@ const (
 	// the database is much larger than RAM; when the working set fits in RAM it is pure
 	// overhead. Set to 0 to disable, 1 to force-enable, or use the env default when unset.
 	OptPrefaultWriteEnable = C.MDBX_opt_prefault_write_enable
+	// OptPresyncThreshold sets how many bytes of not-yet-synced data may accumulate before
+	// SyncPoll/Sync performs a preliminary flush without holding the transaction lock
+	// (MDBX_opt_presync_threshold, new in libmdbx 0.14.3). Pushing the bulk of the data out
+	// early shortens the locked final stage of the sync. A too large threshold lengthens the
+	// latency spikes it is meant to smooth; a too small one multiplies sync calls and their
+	// overhead. Value in bytes: minimum 1, maximum 2 GiB, default 256 KiB.
+	OptPresyncThreshold = C.MDBX_opt_presync_threshold
 )
 
 var (

--- a/mdbx/env_test.go
+++ b/mdbx/env_test.go
@@ -201,6 +201,22 @@ func TestEnv_SetMaxReader(t *testing.T) {
 	}
 }
 
+func TestEnv_PresyncThreshold(t *testing.T) {
+	env, _ := setup(t)
+
+	const threshold = uint64(8 * 1024 * 1024)
+	if err := env.SetOption(OptPresyncThreshold, threshold); err != nil {
+		t.Fatal(err)
+	}
+	got, err := env.GetOption(OptPresyncThreshold)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != threshold {
+		t.Errorf("presync threshold: %v (!= %v)", got, threshold)
+	}
+}
+
 func TestEnv_SetDebug(t *testing.T) {
 	env, err := NewEnv(Default)
 	if err != nil {


### PR DESCRIPTION
Follow-up to #245. libmdbx 0.14.3 added `MDBX_opt_presync_threshold`; this exposes it as `OptPresyncThreshold`, matching how the other `MDBX_opt_*` values are surfaced.

## What it does

It sets the volume of not-yet-synced data, in bytes, above which `SyncPoll`/`Sync` performs a **preliminary flush without holding the transaction lock**. That pushes the bulk of the data to disk early, so the final stage — the part that does hold the lock and updates the meta-page — has much less left to write.

The tuning is a trade-off in both directions: too large a threshold and the latency spike it exists to smooth comes back; too small and you pay for many more flush calls. Value in bytes, minimum 1, maximum 2 GiB, **default 256 KiB**.

```go
err := env.SetOption(mdbx.OptPresyncThreshold, 8<<20)
```

Relevant to callers that drive `Sync`/`SyncPoll` from a goroutine other than the writer — the pre-flush is exactly the path that goroutine takes.

## Validation

`TestEnv_PresyncThreshold` round-trips the value through `SetOption`/`GetOption`, which also proves the constant maps to a live option rather than a stale enum slot. Passes locally on darwin/arm64.
