### PR TITLE
build: vendor libmdbx with git archive instead of a working-tree copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /bin/
 /build
 
+# staging dir of `make cp`, left behind only if a re-vendor is interrupted
+/libmdbx.staging/
+
 # Test databases and benchmark data
 testdata/
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: deps all test race bin
+.PHONY: deps all test race bin cp
 
 MASTER_COMMIT=`git rev-parse --short origin/master`
 
@@ -27,6 +27,24 @@ clean:
 tools: clean
 	cd libmdbx && MDBX_BUILD_TIMESTAMP=unknown CFLAGS="${CFLAGS} -Wno-unknown-warning-option -Wno-enum-int-mismatch -Wno-strict-prototypes -Wno-unused-but-set-variable" make tools
 
+# Re-vendor libmdbx from a local upstream clone. Exports the tracked files of
+# LIBMDBX_REF -- build artifacts left in the clone's working tree are never
+# copied -- into a staging dir, drops upstream CI configs that cannot run from a
+# vendored subdirectory, restores our keep.go, and swaps the result in. Stale
+# files removed upstream disappear, which a plain copy would leave behind.
+#
+#   make cp                              # ../libmdbx at HEAD
+#   make cp LIBMDBX_REF=v0.14.3          # a tag
+#   make cp LIBMDBX_SRC=/path/to/libmdbx # a clone elsewhere
+LIBMDBX_SRC ?= ../libmdbx
+LIBMDBX_REF ?= HEAD
+
 cp:
-	#cd ../libmdbx && make dist
-	cp -R ./../libmdbx/* ./libmdbx/
+	@git -C $(LIBMDBX_SRC) rev-parse --verify --quiet $(LIBMDBX_REF)^{commit} >/dev/null || \
+		{ echo "make cp: $(LIBMDBX_SRC) is not a git clone, or $(LIBMDBX_REF) is unknown there"; exit 1; }
+	@echo "vendoring `git -C $(LIBMDBX_SRC) describe --tags --always $(LIBMDBX_REF)` from $(LIBMDBX_SRC)"
+	rm -rf ./libmdbx.staging && mkdir ./libmdbx.staging
+	git -C $(LIBMDBX_SRC) archive --format=tar $(LIBMDBX_REF) | tar -x -C ./libmdbx.staging
+	rm -rf ./libmdbx.staging/.github ./libmdbx.staging/.sourcecraft
+	cp ./libmdbx/keep.go ./libmdbx.staging/keep.go
+	rm -rf ./libmdbx && mv ./libmdbx.staging ./libmdbx

--- a/README.md
+++ b/README.md
@@ -232,14 +232,23 @@ On FreeBSD 10, you must explicitly set `CC` (otherwise it will fail with a crypt
 
 ## Update C code
 
-In `libmdbx` repo: `make dist && cp -R ./dist/* ./../mdbx-go/libmdbx/`. Then in mdbx-go repo: `make cp`
+`make cp` re-vendors `libmdbx/` from a local upstream clone — `../libmdbx` at `HEAD` by default:
 
-On mac (`--default-names` was removed from Homebrew long ago — install plain `gnu-sed` and prepend its `gnubin` to `PATH`):
 ```
-brew install gnu-sed
-# Intel macs:        /usr/local/opt/gnu-sed/libexec/gnubin
-# Apple Silicon:     /opt/homebrew/opt/gnu-sed/libexec/gnubin
-PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH" make cp
+git -C ../libmdbx fetch --tags && git -C ../libmdbx checkout v0.14.3
+make cp
+
+make cp LIBMDBX_REF=v0.14.3            # or name the ref instead of checking it out
+make cp LIBMDBX_SRC=/path/to/libmdbx   # clone lives elsewhere
+```
+
+Only the files tracked at that ref are vendored, so build artifacts sitting in the clone's
+working tree stay out, and files deleted upstream are dropped instead of lingering. Upstream's
+`.github/` and `.sourcecraft/` CI configs are skipped — they cannot run from a vendored
+subdirectory — and `libmdbx/keep.go` is preserved. Then rebuild and test:
+
+```
+go build ./... && make test
 ```
 
 ## Build binaries


### PR DESCRIPTION
Follow-up to #245. `make cp` was:

```make
cp -R ./../libmdbx/* ./libmdbx/
```

Two problems, both of which have already left marks in this repo:

- **It copies the upstream clone's working tree**, not its committed content. Anything sitting there comes along — which is how build byproducts like `probe4std-gnu++23.err` became tracked files here.
- **It never deletes.** Files removed upstream stay vendored forever, and a rename lands as both names — `valgrind_suppress.txt` and `valgrind.supp` coexisted until #245 cleaned it up by hand.

## What this does instead

Export the files **tracked at a ref** with `git archive` into a staging dir, drop upstream's `.github/` and `.sourcecraft/` (they cannot run from a vendored subdirectory), restore our `keep.go`, and swap the staging dir in — so `libmdbx/` is replaced rather than merged, and a failed export leaves the existing tree untouched.

```
make cp                              # ../libmdbx at HEAD
make cp LIBMDBX_REF=v0.14.3          # a tag, without checking it out
make cp LIBMDBX_SRC=/path/to/libmdbx # clone elsewhere
```

An unknown ref or a non-clone `LIBMDBX_SRC` fails before anything is touched, instead of silently copying nothing. README's "Update C code" section is rewritten to match; its `gnu-sed` note applied to running `make dist` upstream and no longer has anything to do with this target. `.gitignore` picks up `/libmdbx.staging/`, which only survives an interrupted run.

## Validation

Against the tree as vendored today, both `make cp` and `make cp LIBMDBX_REF=v0.14.3` reproduce `libmdbx/` **byte-for-byte** — `git status` reports zero changes under it — so the new path is a faithful replacement for what the last bump produced by hand. `make cp LIBMDBX_REF=nope` fails fast and leaves the tree untouched. `go build ./...` passes afterwards.
