### PR TITLE
mdbx: release closeLock when a cross-thread Abort panics

### DIFF
--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -344,14 +344,18 @@ func (txn *Txn) abort() {
 
 	// Get a read-lock on the environment so we can abort txn if needed.
 	// txn.env **should** terminate all readers otherwise when it closes.
+	//
+	// Released with defer because strictThreadCheck panics by design: an
+	// unguarded RUnlock would be skipped on that path, leaving the read lock
+	// held forever and deadlocking every later Env.Close.
 	txn.env.closeLock.RLock()
+	defer txn.env.closeLock.RUnlock()
 	if txn.env.strictThreadCheck {
 		txn.strictThreadCheck()
 	}
 	if txn.env._env != nil {
 		C.mdbx_txn_abort(txn._txn)
 	}
-	txn.env.closeLock.RUnlock()
 
 	txn.clearTxn()
 }

--- a/mdbx/txn_strictthread_test.go
+++ b/mdbx/txn_strictthread_test.go
@@ -1,0 +1,95 @@
+package mdbx
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/erigontech/mdbx-go/mdbx/threads"
+)
+
+// Under strict thread mode Txn.abort panics by design when it runs on a
+// different OS thread than the one that began the txn.  That panic must not
+// leave Env.closeLock read-locked: Env.Close takes the same lock for writing,
+// so a leaked read lock deadlocks every later Close.
+func TestTxn_AbortForeignThreadPanicDoesNotLeakCloseLock(t *testing.T) {
+	env, err := NewEnv(Default)
+	if err != nil {
+		t.Fatalf("env: %v", err)
+	}
+	// Deliberately not using setup(), which registers Close as a Cleanup: this
+	// test has to call Close itself and bound how long it may block.
+	const pageSize = 4096
+	if err := env.SetGeometry(-1, -1, 64*1024*pageSize, -1, -1, pageSize); err != nil {
+		t.Fatalf("geometry: %v", err)
+	}
+	if err := env.Open(t.TempDir(), 0, 0664); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	env.SetStrictThreadMode(true)
+
+	// Goroutine A begins the txn and stays pinned to its OS thread for the
+	// rest of the test, so that thread cannot be recycled under goroutine B.
+	var (
+		txnc    = make(chan *Txn, 1)
+		tidA    = make(chan uint64, 1)
+		release = make(chan struct{})
+	)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		txn, err := env.BeginTxn(nil, Readonly)
+		if err != nil {
+			t.Errorf("begin: %v", err)
+			txnc <- nil
+			return
+		}
+		tidA <- threads.CurrentThreadID()
+		txnc <- txn
+		<-release
+	}()
+	txn := <-txnc
+	if txn == nil {
+		t.FailNow()
+	}
+	threadA := <-tidA
+
+	// Goroutine B aborts it from a different thread and recovers the expected
+	// panic -- what a Txn pool's Close does when it drains a txn begun
+	// elsewhere.
+	var (
+		panicked = make(chan any, 1)
+		tidB     = make(chan uint64, 1)
+	)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		tidB <- threads.CurrentThreadID()
+		defer func() { panicked <- recover() }()
+		txn.Abort()
+	}()
+	threadB := <-tidB
+	recovered := <-panicked
+	close(release)
+
+	if threadA == threadB {
+		t.Skipf("goroutines landed on the same OS thread (%d); nothing to check", threadA)
+	}
+	if recovered == nil {
+		t.Fatalf("cross-thread Abort did not panic (thread %d begun, %d aborting)", threadA, threadB)
+	}
+	t.Logf("recovered expected panic: %v", recovered)
+
+	// The regression: Close must not block on a read lock the panic leaked.
+	env.SetStrictThreadMode(false)
+	closed := make(chan error, 1)
+	go func() { closed <- env.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Env.Close blocked: the panicking Abort leaked env.closeLock")
+	}
+}


### PR DESCRIPTION
## The bug

`Txn.abort()` takes `env.closeLock.RLock()` and releases it manually at the end of the function. In between it calls `strictThreadCheck()`, which **panics by design** when the aborting thread is not the one that began the txn:

```go
txn.env.closeLock.RLock()
if txn.env.strictThreadCheck {
    txn.strictThreadCheck()   // panics here
}
if txn.env._env != nil {
    C.mdbx_txn_abort(txn._txn)
}
txn.env.closeLock.RUnlock()   // never reached
```

The panic skips the `RUnlock`, so the read lock is held forever. `Env.Close` takes the same lock for writing, so every subsequent `Close` blocks indefinitely.

The panic is recoverable, so a caller can survive it and then deadlock later on an unrelated `Close` — with a stack trace that points at `Close`, not at the abort that actually caused it.

## Why it matters

Aborting a txn from a foreign thread isn't hypothetical: it's what any `Txn` pool does when it drains transactions begun on other goroutines. I hit this while working on `exp/mdbxpool`, where `Pool.Close` aborts pooled readers from whichever goroutine calls it.

## The fix

Release with `defer`, matching `Txn.Park` and `Txn.Unpark`, which already guard the same lock that way — `abort` was the only one of the three doing it manually.

`clearTxn` now runs while the read lock is held. It only writes Go fields and doesn't touch `closeLock`, so that's harmless.

## Test

`TestTxn_AbortForeignThreadPanicDoesNotLeakCloseLock` pins two goroutines to distinct OS threads (goroutine A stays parked so its thread can't be recycled under B), aborts from the wrong one, recovers the expected panic, then asserts `Env.Close` completes within 20s.

Verified it actually catches the bug:

```
# without the fix
    txn_strictthread_test.go:81: recovered expected panic: thread mismatch. not allowed current 4826306, open in 4826292
    txn_strictthread_test.go:93: Env.Close blocked: the panicking Abort leaked env.closeLock
--- FAIL: TestTxn_AbortForeignThreadPanicDoesNotLeakCloseLock (20.00s)

# with the fix
--- PASS: TestTxn_AbortForeignThreadPanicDoesNotLeakCloseLock (0.00s)
```

It skips rather than fails if the two goroutines happen to land on the same OS thread, so it can't flake.

`go test ./mdbx/...` and `go test -race ./mdbx` both pass.